### PR TITLE
Include package CMFCore for permission in configure.zcml

### DIFF
--- a/Products/windowZ/configure.zcml
+++ b/Products/windowZ/configure.zcml
@@ -3,6 +3,8 @@
            xmlns:gs="http://namespaces.zope.org/genericsetup"
            i18n_domain="windowZ">
 
+  <include package="Products.CMFCore" file="configure.zcml" />
+
   <gs:registerProfile
       name="default"
       title="windowZ"


### PR DESCRIPTION
This dependence was necessary to correct this error:
Plone 4

...
zope.configuration.config.ConfigurationExecutionError: <class 'zope.component.interfaces.ComponentLookupError'>: (<InterfaceClass zope.security.interfaces.IPermission>, 'cmf.ManagePortal')
  in:
  File "/plone4/eggs/Products.windowZ-1.4.1-py2.6.egg/Products/windowZ/configure.zcml", line 14.2-19.8
    <browser:page
        for=".interfaces.IWindowZTool"
        name="edit"
        class=".controlpanel.WindowZControlPanelForm"
        permission="cmf.ManagePortal"
        />

thanks and regards
